### PR TITLE
Revert header contact structure and adjust print styles

### DIFF
--- a/ziad-cv.html
+++ b/ziad-cv.html
@@ -27,31 +27,32 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      text-align: center; /* Ensures text within header is centered */
+      /* text-align: center; */
     }
 
     header h1 {
       margin: 0;
       font-size: 1.8rem;
-      /* display: flex; */ /* Not needed if header is text-align: center */
+      display: flex;
     }
 
-    .contact-info-wrapper { /* Renamed from contact-links-wrapper for clarity */
+    /* Reverted: Styles for the overall wrapper of contact links */
+    /* .contact-links-wrapper {
       display: flex;
-      flex-direction: column; /* Stack contact lines and social links vertically */
-      align-items: center; /* Center items horizontally */
-      gap: 0.5rem; /* Reduced gap for a tighter look */
+      justify-content: center;
+      gap: 1rem;
       width: 100%;
+      flex-wrap: wrap;
       margin-top: 0.5rem;
-    }
+    } */
 
     .contact-links {
       font-size: 1rem;
       color: #555;
       display: flex;
-      justify-content: center;
-      gap: 1rem;
-      flex-wrap: wrap; /* Allow wrapping for smaller screens */
+      justify-content: center; /* Center items within each .contact-links div */
+      gap: 1rem; /* Gap between items in a single .contact-links div */
+      flex-wrap: wrap; /* Allow items within a .contact-links div to wrap */
     }
 
     .contact-links a {
@@ -238,20 +239,35 @@
         content: ""; /* Do not show the href for these specific links */
       }
 
-      .contact-info-wrapper .contact-links {
-        flex-direction: row !important; /* Ensure they stay in a row for print */
-        justify-content: center !important;
-        gap: 1rem !important; /* Restore gap for print if it was changed by responsive styles */
+      /* Adjusting print style for .contact-links to ensure they try to stay in a row */
+      .contact-links-wrapper .contact-links, /* If .contact-links-wrapper is used */
+      header > .contact-links { /* If .contact-links are direct children of header */
+        /* This might be tricky if they were meant to be separate lines before.
+           The original structure had two .contact-links divs.
+           We want the *content* of the first .contact-links div to be on one line.
+        */
       }
 
-      .contact-links span {
-        margin: 0 0.25rem !important; /* Restore original margins for print */
+      /* Ensure items within the primary contact-links div are in a row for print */
+      .contact-links-wrapper > .contact-links:first-child,
+      header > .contact-links-wrapper > .contact-links:first-child { /* Targeting the first contact link group */
+        flex-direction: row !important;
+        justify-content: center !important; /* Or flex-start if preferred */
+        gap: 1rem !important;
       }
+
+      .contact-links-wrapper > .contact-links:first-child span,
+      header > .contact-links-wrapper > .contact-links:first-child span {
+        margin: 0 0.25rem !important;
+      }
+
 
       /* Hide elements not essential for print if any - for a CV, most are essential */
       /* .social-icon svg { display: none; } */ /* Example: if icons are not needed */
 
-      .contact-links span:not(:last-child)::after {
+      /* This rule for pipes should apply to the first contact-links div if that's the desired outcome */
+      .contact-links-wrapper > .contact-links:first-child span:not(:last-child)::after,
+      header > .contact-links-wrapper > .contact-links:first-child span:not(:last-child)::after {
         content: " | ";
         display: inline;
         margin: 0 0.5em;
@@ -269,28 +285,31 @@
   <div class="container">
     <header>
       <h1>Ziad Mahmoud Al-Masry</h1>
-      <div class="contact-info-wrapper">
+      <!-- Reverted to original structure with two .contact-links divs -->
+      <div class="contact-links-wrapper">
         <div class="contact-links">
           <span>📞 <a href="tel:+201068202083">+20 106 820 2083</a></span>
           <span>| 📧 <a href="mailto:ziadmasi2122@gmail.com">ziadmasi2122@gmail.com</a></span>
           <span>| 🔗<a href="https://ziad392.github.io/Ziad-Portfolio/ziad-portfolio.html"> View My Portfolio</a></span>
           <span>| 📍 Cairo, Egypt 🇪🇬</span>
         </div>
-        <div class="social-links">
-          <a href="https://www.linkedin.com/in/z-masry" class="social-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#0A66C2" class="bi bi-linkedin"
-              viewBox="0 0 16 16">
-              <path
-                d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248S2.4 3.226 2.4 3.934c0 .694.521 1.248 1.327 1.248zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z" />
-            </svg>
-          </a>
-          <a href="https://github.com/ZIAD392" class="social-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#181717" class="bi bi-github"
-              viewBox="0 0 16 16">
-              <path
-                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8" />
-            </svg>
-          </a>
+        <div class="contact-links"> <!-- This div now specifically for social links -->
+          <span class="social-links"> <!-- Kept this span for direct styling of social icons if needed -->
+            <a href="https://www.linkedin.com/in/z-masry" class="social-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#0A66C2" class="bi bi-linkedin"
+                viewBox="0 0 16 16">
+                <path
+                  d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248S2.4 3.226 2.4 3.934c0 .694.521 1.248 1.327 1.248zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z" />
+              </svg>
+            </a>
+            <a href="https://github.com/ZIAD392" class="social-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#181717" class="bi bi-github"
+                viewBox="0 0 16 16">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8" />
+              </svg>
+            </a>
+          </span>
         </div>
       </div>
     </header>


### PR DESCRIPTION
- Removed 'contact-info-wrapper' and reverted to original 'contact-links-wrapper' structure with two 'contact-links' divs in the header.
- Updated CSS to reflect the reverted HTML structure for header contact information.
- Ensured print styles correctly target primary contact links to hide their hrefs and maintain single-line layout with pipe separators.